### PR TITLE
Upgrade esprit to git HEAD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ authors = ["Renée Kooi <renee@kooi.me>"]
 
 [dependencies]
 digest = "0.7.2"
-easter = "0.0.5"
-esprit = "0.0.5"
+easter = { version = "0.0.5", path = "../esprit/crates/easter" }
+esprit = { version = "0.0.5", path = "../esprit" }
 estree-detect-requires = { path = "crates/estree-detect-requires" }
 node-resolve = "2.0.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ digest = "0.7.2"
 easter = { version = "0.0.5", path = "../esprit/crates/easter" }
 esprit = { version = "0.0.5", path = "../esprit" }
 estree-detect-requires = { path = "crates/estree-detect-requires" }
+node-core-shims = { path = "crates/node-core-shims" }
 node-resolve = "2.0.0"
 serde_json = "1.0"
 sha-1 = "0.7.0"

--- a/crates/estree-detect-requires/Cargo.toml
+++ b/crates/estree-detect-requires/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 authors = ["Renée Kooi <renee@kooi.me>"]
 
 [dependencies]
-easter = "0.0.5"
-esprit = "0.0.5"
+easter = { version = "0.0.5", path = "../../../esprit/crates/easter" }
+esprit = { version = "0.0.5", path = "../../../esprit" }
 
 [lib]
 doctest = false

--- a/crates/estree-detect-requires/src/lib.rs
+++ b/crates/estree-detect-requires/src/lib.rs
@@ -2,9 +2,9 @@ extern crate easter;
 
 mod walk;
 
-use easter::expr::Expr;
+use easter::expr::{Expr, ExprListItem};
 use easter::id::Id;
-use easter::prog::Script;
+use easter::stmt::Script;
 use walk::{Walker, Callbacks};
 
 /// Find require() calls in an ESTree Script node (from the easter crate).
@@ -43,7 +43,7 @@ impl Callbacks for FindRequires {
     fn pre_expr(&mut self, expr: &Expr) -> () {
         if let Expr::Call(_, ref callee, ref args) = *expr {
             if is_require_name(callee) {
-                if let Some(&Expr::String(_, ref val)) = args.first() {
+                if let Some(&ExprListItem::Expr(Expr::String(_, ref val))) = args.first() {
                     self.modules.push(val.value.clone());
                 }
             }

--- a/crates/node-core-shims/Cargo.toml
+++ b/crates/node-core-shims/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "node-core-shims"
+version = "0.1.0"
+authors = ["Renée Kooi <renee@kooi.me>"]
+build = "build.rs"
+
+[dependencies]

--- a/crates/node-core-shims/build.rs
+++ b/crates/node-core-shims/build.rs
@@ -1,0 +1,5 @@
+use std::process::Command;
+
+fn main() {
+    Command::new("npm").args(&["install"]).status().unwrap();
+}

--- a/crates/node-core-shims/package.json
+++ b/crates/node-core-shims/package.json
@@ -1,0 +1,23 @@
+{
+  "dependencies": {
+    "assert": "^1.4.1",
+    "browserify-zlib": "^0.2.0",
+    "buffer": "^5.1.0",
+    "crypto-browserify": "^3.12.0",
+    "events": "^2.0.0",
+    "https-browserify": "^1.0.0",
+    "os-browserify": "^0.3.0",
+    "path-browserify": "0.0.0",
+    "process": "^0.11.10",
+    "querystring-es3": "^0.2.1",
+    "readable-stream": "^2.3.6",
+    "stream-browserify": "^2.0.1",
+    "stream-http": "^2.8.1",
+    "string_decoder": "^1.1.1",
+    "timers-browserify": "^2.0.10",
+    "tty-browserify": "0.0.1",
+    "url": "^0.11.0",
+    "util": "^0.10.3",
+    "vm-browserify": "^1.0.1"
+  }
+}

--- a/crates/node-core-shims/src/lib.rs
+++ b/crates/node-core-shims/src/lib.rs
@@ -1,0 +1,30 @@
+use std::collections::HashMap;
+
+#[derive(Clone)]
+pub enum NodeBuiltin {
+    Stub,
+    Package(String),
+}
+
+pub fn get_builtin_mapping() -> HashMap<String, NodeBuiltin> {
+    [
+        ("assert".to_string(), NodeBuiltin::Package("assert/".to_string())),
+        ("buffer".to_string(), NodeBuiltin::Package("buffer/".to_string())),
+        ("crypto".to_string(), NodeBuiltin::Package("crypto-browserify".to_string())),
+        ("events".to_string(), NodeBuiltin::Package("events/".to_string())),
+        ("fs".to_string(), NodeBuiltin::Stub),
+        ("http".to_string(), NodeBuiltin::Package("stream-http".to_string())),
+        ("https".to_string(), NodeBuiltin::Package("https-browserify".to_string())),
+        ("os".to_string(), NodeBuiltin::Package("os-browserify".to_string())),
+        ("path".to_string(), NodeBuiltin::Package("path-browserify".to_string())),
+        ("process".to_string(), NodeBuiltin::Package("process/".to_string())),
+        ("querystring".to_string(), NodeBuiltin::Package("querystring-es3".to_string())),
+        ("stream".to_string(), NodeBuiltin::Package("stream-browserify".to_string())),
+        ("string_decoder".to_string(), NodeBuiltin::Package("string_decoder".to_string())),
+        ("timers".to_string(), NodeBuiltin::Package("timers-browserify".to_string())),
+        ("tty".to_string(), NodeBuiltin::Package("tty-browserify".to_string())),
+        ("url".to_string(), NodeBuiltin::Package("url/".to_string())),
+        ("util".to_string(), NodeBuiltin::Package("util/".to_string())),
+        ("vm".to_string(), NodeBuiltin::Package("vm-browserify".to_string())),
+    ].iter().cloned().collect()
+}

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,18 +1,13 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use node_resolve::{Resolver, is_core_module};
+use node_core_shims::{NodeBuiltin, get_builtin_mapping};
 use quicli::prelude::Result;
 
 /// Map builtin module names to a resolvable module ID.
 pub trait Builtins {
     fn is_builtin(&self, module_id: &str) -> bool;
     fn resolve(&self, resolver: &Resolver, module_id: &str) -> Result<Option<PathBuf>>;
-}
-
-#[derive(Clone)]
-pub enum NodeBuiltin {
-    Stub,
-    Package(String),
 }
 
 /// Support Node builtins.
@@ -25,26 +20,7 @@ impl NodeBuiltins {
     pub fn new(basedir: PathBuf) -> Self {
         NodeBuiltins {
             basedir,
-            mapping: [
-                ("assert".to_string(), NodeBuiltin::Package("assert/".to_string())),
-                ("buffer".to_string(), NodeBuiltin::Package("buffer/".to_string())),
-                ("crypto".to_string(), NodeBuiltin::Package("crypto-browserify".to_string())),
-                ("events".to_string(), NodeBuiltin::Package("events/".to_string())),
-                ("fs".to_string(), NodeBuiltin::Stub),
-                ("http".to_string(), NodeBuiltin::Package("stream-http".to_string())),
-                ("https".to_string(), NodeBuiltin::Package("https-browserify".to_string())),
-                ("os".to_string(), NodeBuiltin::Package("os-browserify".to_string())),
-                ("path".to_string(), NodeBuiltin::Package("path-browserify".to_string())),
-                ("process".to_string(), NodeBuiltin::Package("process/".to_string())),
-                ("querystring".to_string(), NodeBuiltin::Package("querystring-es3".to_string())),
-                ("stream".to_string(), NodeBuiltin::Package("stream-browserify".to_string())),
-                ("string_decoder".to_string(), NodeBuiltin::Package("string_decoder".to_string())),
-                ("timers".to_string(), NodeBuiltin::Package("timers-browserify".to_string())),
-                ("tty".to_string(), NodeBuiltin::Package("tty-browserify".to_string())),
-                ("url".to_string(), NodeBuiltin::Package("url/".to_string())),
-                ("util".to_string(), NodeBuiltin::Package("util/".to_string())),
-                ("vm".to_string(), NodeBuiltin::Package("vm-browserify".to_string())),
-            ].iter().cloned().collect(),
+            mapping: get_builtin_mapping(),
         }
     }
 }

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,0 +1,79 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use node_resolve::{Resolver, is_core_module};
+use quicli::prelude::Result;
+
+/// Map builtin module names to a resolvable module ID.
+pub trait Builtins {
+    fn is_builtin(&self, module_id: &str) -> bool;
+    fn resolve(&self, resolver: &Resolver, module_id: &str) -> Result<Option<PathBuf>>;
+}
+
+#[derive(Clone)]
+pub enum NodeBuiltin {
+    Stub,
+    Package(String),
+}
+
+/// Support Node builtins.
+pub struct NodeBuiltins {
+    basedir: PathBuf,
+    mapping: HashMap<String, NodeBuiltin>,
+}
+
+impl NodeBuiltins {
+    pub fn new(basedir: PathBuf) -> Self {
+        NodeBuiltins {
+            basedir,
+            mapping: [
+                ("assert".to_string(), NodeBuiltin::Package("assert/".to_string())),
+                ("buffer".to_string(), NodeBuiltin::Package("buffer/".to_string())),
+                ("crypto".to_string(), NodeBuiltin::Package("crypto-browserify".to_string())),
+                ("events".to_string(), NodeBuiltin::Package("events/".to_string())),
+                ("fs".to_string(), NodeBuiltin::Stub),
+                ("http".to_string(), NodeBuiltin::Package("stream-http".to_string())),
+                ("https".to_string(), NodeBuiltin::Package("https-browserify".to_string())),
+                ("os".to_string(), NodeBuiltin::Package("os-browserify".to_string())),
+                ("path".to_string(), NodeBuiltin::Package("path-browserify".to_string())),
+                ("process".to_string(), NodeBuiltin::Package("process/".to_string())),
+                ("querystring".to_string(), NodeBuiltin::Package("querystring-es3".to_string())),
+                ("stream".to_string(), NodeBuiltin::Package("stream-browserify".to_string())),
+                ("string_decoder".to_string(), NodeBuiltin::Package("string_decoder".to_string())),
+                ("timers".to_string(), NodeBuiltin::Package("timers-browserify".to_string())),
+                ("tty".to_string(), NodeBuiltin::Package("tty-browserify".to_string())),
+                ("url".to_string(), NodeBuiltin::Package("url/".to_string())),
+                ("util".to_string(), NodeBuiltin::Package("util/".to_string())),
+                ("vm".to_string(), NodeBuiltin::Package("vm-browserify".to_string())),
+            ].iter().cloned().collect(),
+        }
+    }
+}
+
+impl Builtins for NodeBuiltins {
+    fn is_builtin(&self, module_id: &str) -> bool {
+        is_core_module(module_id)
+    }
+
+    fn resolve(&self, resolver: &Resolver, module_id: &str) -> Result<Option<PathBuf>> {
+        let builtin: &NodeBuiltin = self.mapping.get(module_id)
+            .unwrap_or_else(|| panic!("Missing builtin mapping for {}", module_id));
+
+        match *builtin {
+            NodeBuiltin::Package(ref package_id) => {
+                resolver
+                    .with_basedir(self.basedir.clone())
+                    .resolve(package_id)
+                    .map(|r| Some(r))
+                    .map_err(|e| e.into())
+            },
+            NodeBuiltin::Stub => Ok(None),
+        }
+    }
+}
+
+/// Do not support any builtins.
+pub struct NoBuiltins;
+impl Builtins for NoBuiltins {
+    fn is_builtin(&self, _module_id: &str) -> bool { false }
+    fn resolve(&self, _resolver: &Resolver, _module_id: &str) -> Result<Option<PathBuf>> { Ok(None) }
+}

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -48,6 +48,10 @@ impl Dependency {
         self.record = Some(Rc::clone(record));
         self
     }
+
+    pub fn set_record(&mut self, record: &Rc<ModuleRecord>) -> () {
+        self.record = Some(Rc::clone(record));
+    }
 }
 
 impl ModuleRecord {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -6,17 +6,48 @@ use digest::generic_array::GenericArray;
 use digest::generic_array::typenum::U20;
 
 /// Map dependency IDs used inside require() to their full paths.
-pub type Dependencies = BTreeMap<String, PathBuf>;
+pub type Dependencies = BTreeMap<String, Dependency>;
 pub type Hash = GenericArray<u8, U20>;
 
 /// A Module.
 #[derive(Debug)]
 pub struct ModuleRecord {
     pub path: Box<Path>,
+    pub id: u32,
     pub source: String,
     pub hash: Hash,
     pub entry: bool,
     pub dependencies: Dependencies,
+}
+
+#[derive(Debug)]
+pub struct Dependency {
+    pub name: String,
+    pub resolved: Option<PathBuf>,
+    pub record: Option<Rc<ModuleRecord>>,
+}
+
+impl Dependency {
+    pub fn uninitialized(name: String) -> Self {
+        Dependency {
+            name,
+            resolved: None,
+            record: None,
+        }
+    }
+
+    pub fn resolved(name: String, resolved: PathBuf) -> Self {
+        Dependency {
+            name,
+            resolved: Some(resolved),
+            record: None,
+        }
+    }
+
+    pub fn with_record(mut self, record: &Rc<ModuleRecord>) -> Self {
+        self.record = Some(Rc::clone(record));
+        self
+    }
 }
 
 impl ModuleRecord {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate estree_detect_requires;
 extern crate time;
 #[macro_use] extern crate quicli;
 
+mod builtins;
 mod graph;
 mod deps;
 mod pack;
@@ -21,11 +22,16 @@ use pack::Pack;
 #[derive(Debug, StructOpt)]
 struct Options {
     entry: String,
+    #[structopt(long = "no-builtins", help = "Exclude shims for builtin modules. Useful when generating a bundle for Node.")]
+    no_builtins: bool,
 }
 
 main!(|args: Options| {
     let start = PreciseTime::now();
-    let mut deps = Deps::new();
+    let mut deps = Deps::new()
+        .include_builtins(!args.no_builtins)
+        .with_builtins_path("./crates/node-core-shims".into());
+
     deps.run(&args.entry)?;
     let mut out = stdout();
     let bundle = Pack::new(&deps).to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ extern crate node_resolve;
 extern crate serde_json;
 extern crate sha1;
 extern crate estree_detect_requires;
+extern crate node_core_shims;
 extern crate time;
 #[macro_use] extern crate quicli;
 

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -27,21 +27,21 @@ impl<'a> Pack<'a> {
             if !first { string.push_str(",\n"); }
             string.push_str(&format!(
                 "{id}:[function(require,exports,module){{\n{source}\n}},{deps}]",
-                id = serde_json::to_string(&path_to_string(&record.path)).unwrap(),
+                id = serde_json::to_string(&record.id).unwrap(),
                 source = record.source,
                 deps = serde_json::to_string(
                     &record.dependencies.iter()
-                        .map(|(key, val)| (key, match val.resolved {
-                             Some(ref path) => path.to_string_lossy().into_owned(),
-                             None => "".into(),
+                        .map(|(key, val)| (key, match val.record {
+                             Some(ref rec) => rec.id,
+                             None => 0,
                          }))
-                        .collect::<BTreeMap<&String, String>>()
+                        .collect::<BTreeMap<&String, u32>>()
                 ).unwrap(),
             ));
             first = false;
 
             if record.entry {
-                entries.push(path_to_string(&record.path));
+                entries.push(record.id);
             }
         }
 
@@ -50,8 +50,4 @@ impl<'a> Pack<'a> {
         string.push_str(");");
         string
     }
-}
-
-fn path_to_string(path: &Path) -> String {
-    path.to_string_lossy().into_owned()
 }

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::path::Path;
 use std::rc::Rc;
 use serde_json;
 use graph::{ModuleMap, ModuleRecord};

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::Path;
 use std::rc::Rc;
 use serde_json;
@@ -28,7 +29,14 @@ impl<'a> Pack<'a> {
                 "{id}:[function(require,exports,module){{\n{source}\n}},{deps}]",
                 id = serde_json::to_string(&path_to_string(&record.path)).unwrap(),
                 source = record.source,
-                deps = serde_json::to_string(&record.dependencies).unwrap(),
+                deps = serde_json::to_string(
+                    &record.dependencies.iter()
+                        .map(|(key, val)| (key, match val.resolved {
+                             Some(ref path) => path.to_string_lossy().into_owned(),
+                             None => "".into(),
+                         }))
+                        .collect::<BTreeMap<&String, String>>()
+                ).unwrap(),
             ));
             first = false;
 


### PR DESCRIPTION
Assumes user has esprit cloned at `../esprit`. probably better as a git submodule, but will have to move everything bundler related into a subfolder so that the workspaces don't overlap